### PR TITLE
update path alias documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,45 +204,24 @@ npm run check
 ### path aliases
 
 You may see imports from paths that are not npm modules and also not relative paths e.g.
-`$lib/Component.svelte`. These are called path aliases and you can define them yourself if you like.
+`$components/Component.svelte`. These are called path aliases and you can define them yourself if you like.
 
-Let's say instead of using a relative file import like `../../../lib/Component.svelte` you want to
-use the alias import `$lib/Component.svelte`. To do that, you first need to define the desired alias
-in your `tsconfig.json` file:
-
-```jsonc
-{
-   "compilerOptions": {
-      "paths": {
-         "$lib/*": ["src/lib/*"]
-      }
-   }
-}
-```
-
-And then also tell [`vite`](https://vitejs.dev/) inside your `svelte.config.js` that you want to use
-that path alias.
+Let's say instead of using a relative file import like `../../../components/Component.svelte` you want to
+use the alias import `$components/Component.svelte`. To do that, you only need to define the desired alias
+in your `svelte.config.js` file:
 
 ```ts
-import { resolve } from 'path'
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-   kit: {
-      vite: {
-         resolve: {
-            alias: {
-               $lib: resolve('./src/lib'),
-            },
-         },
-      },
-   },
-}
-
-export default config
+  kit: {
+    alias: {
+      $components: 'src/components',
+    }
+  }
+};
 ```
 
-You can define as many aliases as you want.
+These aliases are automatically passed to Vite and TypeScript. You can define as many aliases as you want.
 
 <!------------------------------------------------------------------------------------------------>
 <!------------------------------------------------------------------------------------------------>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,6 +9,10 @@ const config = {
 
 	kit: {
 		adapter: adapter(),
+		alias: {
+			$lib: 'src/lib',
+			$models: 'src/models',
+		},
 	},
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,6 @@
 {
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
-		"paths": {
-			"$lib": ["src/lib"],
-			"$lib/*": ["src/lib/*"],
-			"$models/*": ["src/models/*"]
-		},
 		"strict": true,
 		"allowUnreachableCode": false,
 		"exactOptionalPropertyTypes": true,

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,16 +1,9 @@
 
 import { sveltekit } from '@sveltejs/kit/vite'
-import { resolve } from 'path'
 
 /** @type {import('vite').UserConfig} */
 const config = {
 	plugins: [sveltekit()],
-	resolve: {
-		alias: {
-			$lib: resolve('./src/lib'),
-			$models: resolve('./src/models'),
-		},
-	},
 }
 
 export default config


### PR DESCRIPTION
adopted `alias` documentation from the [relevant `SvelteKit` docs](https://kit.svelte.dev/docs/configuration#alias) (screenshot for posterity)

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/20136585/179962372-39f5b235-19b7-4053-b5fa-38153f77ead1.png">
